### PR TITLE
Referencing latest version of ratatui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["ratatui"]
 
 [dependencies]
 rand = "0.8.5"
-ratatui = { version = "0.22.0", optional = true }
+ratatui = { version = "0.24.0", optional = true }
 tui = { version = "0.19.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes compilation error encountered when using latest (v0.24.0) of ratatui:

```
the trait `Widget` is not implemented for `Throbber<'_>`
```