### PR TITLE
⬆ Update ratatui from 0.24 to 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["ratatui"]
 
 [dependencies]
 rand = "0.8.5"
-ratatui = { version = "0.24.0", optional = true }
+ratatui = { version = "0.26.0", optional = true }
 tui = { version = "0.19.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Use [latest ratatui release](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.0)