### PR TITLE
Remove default features from production bundle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 rand = "0.8.5"
+ratatui = { version="0.28.1", default-features = false }
+
+[dev-dependencies]
 ratatui = "0.28.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "throbber-widgets-tui"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.74.0"
 authors = ["arkbig"]

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ cargo license --avoid-build-deps --avoid-dev-deps | awk -F ":" 'BEGIN {printf "|
 |Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT (3)| linux-raw-sys, rustix, wasi|
 |Apache-2.0 OR BSD-2-Clause OR MIT (2)| zerocopy, zerocopy-derive|
 |Apache-2.0 OR BSL-1.0 (1)| ryu|
-|Apache-2.0 OR MIT (50)| ahash, allocator-api2, bitflags, cassowary, cfg-if, either, errno, getrandom, hashbrown, heck, hermit-abi, itertools, itoa, libc, lock_api, log, once_cell, parking_lot, parking_lot_core, paste, ppv-lite86, proc-macro2, quote, rand, rand_chacha, rand_core, rustversion, scopeguard, signal-hook, signal-hook-mio, signal-hook-registry, smallvec, static_assertions, syn, unicode-segmentation, unicode-truncate, unicode-width, winapi, winapi-i686-pc-windows-gnu, winapi-x86_64-pc-windows-gnu, windows-sys, windows-targets, windows_aarch64_gnullvm, windows_aarch64_msvc, windows_i686_gnu, windows_i686_gnullvm, windows_i686_msvc, windows_x86_64_gnu, windows_x86_64_gnullvm, windows_x86_64_msvc|
+|Apache-2.0 OR MIT (49)| allocator-api2, bitflags, cassowary, cfg-if, either, equivalent, errno, getrandom, hashbrown, heck, hermit-abi, itertools, itoa, libc, lock_api, log, parking_lot, parking_lot_core, paste, ppv-lite86, proc-macro2, quote, rand, rand_chacha, rand_core, rustversion, scopeguard, signal-hook, signal-hook-mio, signal-hook-registry, smallvec, static_assertions, syn, unicode-segmentation, unicode-truncate, unicode-width, winapi, winapi-i686-pc-windows-gnu, winapi-x86_64-pc-windows-gnu, windows-sys, windows-targets, windows_aarch64_gnullvm, windows_aarch64_msvc, windows_i686_gnu, windows_i686_gnullvm, windows_i686_msvc, windows_x86_64_gnu, windows_x86_64_gnullvm, windows_x86_64_msvc|
 |MIT (11)| castaway, compact_str, crossterm, crossterm_winapi, instability, lru, mio, ratatui, redox_syscall, strum, strum_macros|
 |MIT OR Unlicense (1)| byteorder|
-|Zlib (1)| throbber-widgets-tui|
+|Zlib (2)| foldhash, throbber-widgets-tui|
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,10 @@ Chain dependencies crates:
 |Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT (3)| linux-raw-sys, rustix, wasi|
 |Apache-2.0 OR BSD-2-Clause OR MIT (2)| zerocopy, zerocopy-derive|
 |Apache-2.0 OR BSL-1.0 (1)| ryu|
-|Apache-2.0 OR MIT (50)| ahash, allocator-api2, bitflags, cassowary, cfg-if, either, errno, getrandom, hashbrown, heck, hermit-abi, itertools, itoa, libc, lock_api, log, once_cell, parking_lot, parking_lot_core, paste, ppv-lite86, proc-macro2, quote, rand, rand_chacha, rand_core, rustversion, scopeguard, signal-hook, signal-hook-mio, signal-hook-registry, smallvec, static_assertions, syn, unicode-segmentation, unicode-truncate, unicode-width, winapi, winapi-i686-pc-windows-gnu, winapi-x86_64-pc-windows-gnu, windows-sys, windows-targets, windows_aarch64_gnullvm, windows_aarch64_msvc, windows_i686_gnu, windows_i686_gnullvm, windows_i686_msvc, windows_x86_64_gnu, windows_x86_64_gnullvm, windows_x86_64_msvc|
+|Apache-2.0 OR MIT (49)| allocator-api2, bitflags, cassowary, cfg-if, either, equivalent, errno, getrandom, hashbrown, heck, hermit-abi, itertools, itoa, libc, lock_api, log, parking_lot, parking_lot_core, paste, ppv-lite86, proc-macro2, quote, rand, rand_chacha, rand_core, rustversion, scopeguard, signal-hook, signal-hook-mio, signal-hook-registry, smallvec, static_assertions, syn, unicode-segmentation, unicode-truncate, unicode-width, winapi, winapi-i686-pc-windows-gnu, winapi-x86_64-pc-windows-gnu, windows-sys, windows-targets, windows_aarch64_gnullvm, windows_aarch64_msvc, windows_i686_gnu, windows_i686_gnullvm, windows_i686_msvc, windows_x86_64_gnu, windows_x86_64_gnullvm, windows_x86_64_msvc|
 |MIT (11)| castaway, compact_str, crossterm, crossterm_winapi, instability, lru, mio, ratatui, redox_syscall, strum, strum_macros|
 |MIT OR Unlicense (1)| byteorder|
-|Zlib (1)| throbber-widgets-tui|
+|Zlib (2)| foldhash, throbber-widgets-tui|
 
 ## License
 


### PR DESCRIPTION
I cannot have `crossterm` as a transitive dependency of my project because I am compiling to target `wasm`

> [!Note]
> I had to also add feature `js` to `getrandom` in order for this lib to work in my project.
> ```
> getrandom = { version = "0.2", features = ["js"] }
> ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated package version to 0.7.1.
	- Introduced a new dependency on the `ratatui` crate for enhanced functionality.

- **Documentation**
	- Updated README.md to reflect changes in dependency counts and clarified throbber widget descriptions.
	- Enhanced documentation in the `src/lib.rs` for the throbber widget, including features and usage examples.

These updates will improve the overall performance and capabilities of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->