### PR TITLE
fix: throbber stops in upper limit

### DIFF
--- a/src/widgets/throbber.rs
+++ b/src/widgets/throbber.rs
@@ -50,7 +50,7 @@ impl ThrobberState {
             let mut rng = rand::thread_rng();
             rng.gen()
         } else {
-            self.index.saturating_add(step)
+            self.index.checked_add(step).unwrap_or(0)
         }
     }
 
@@ -335,5 +335,16 @@ mod tests {
         let throbber = Throbber::default().use_type(crate::symbols::throbber::WhichUse::Full);
         let line: ratatui::text::Line = throbber.into();
         assert_eq!(line.spans[0].content, "⠿ ");
+    }
+
+    #[test]
+    fn throbber_reaches_upper_limit_step_resets_to_zero() {
+        let mut throbber_state = ThrobberState::default();
+
+        for _ in 0..i8::MAX {
+            throbber_state.calc_next();
+        }
+        throbber_state.calc_next();
+        assert!(throbber_state.index() != i8::MAX);
     }
 }


### PR DESCRIPTION
When `i8::MAX` is reached, we continue with `ThrobberState.index` to zero so the throbber keeps swirling on the next call to `calc_next()`

Test included.

Fixes #19 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the Throbber component to prevent index overflow, ensuring it resets correctly when limits are reached.

- **Tests**
	- Added a new test case to verify the Throbber's behavior when reaching its upper limit, enhancing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->