### PR TITLE
Derive PartialEq/Eq for structs

### DIFF
--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,6 +1,6 @@
 pub mod throbber {
     /// A set of symbols to be rendered by throbber.
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct Set {
         pub full: &'static str,
         pub empty: &'static str,
@@ -10,7 +10,7 @@ pub mod throbber {
     /// Rendering object.
     ///
     /// If Spin is specified, ThrobberState.index is used.
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum WhichUse {
         Full,
         Empty,

--- a/src/widgets/throbber.rs
+++ b/src/widgets/throbber.rs
@@ -1,7 +1,7 @@
 use rand::Rng as _;
 
 /// State to be used for Throbber render.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ThrobberState {
     /// Index of Set.symbols used when Spin is specified for WhichUse.
     ///
@@ -111,7 +111,7 @@ impl ThrobberState {
 /// let throbber_state = throbber_widgets_tui::ThrobberState::default();
 /// // frame.render_stateful_widget(throbber, chunks[0], &mut throbber_state);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Throbber<'a> {
     label: Option<ratatui::text::Span<'a>>,
     style: ratatui::style::Style,


### PR DESCRIPTION
Add PartialEq and Eq implementations for Throbber widget

Without PartialEq and Eq implementations, the Throbber widget cannot be used in contexts where these traits are required — for example, as a field in enums that derive or implement PartialEq/Eq. This is a common pattern when widgets are represented as enum variants and need to be compared or matched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for comparing certain interface elements for equality, enhancing consistency in behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->