### PR TITLE
Make rand an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ license = "Zlib"
 keywords = ["tui", "widgets"]
 categories = ["command-line-utilities"]
 
+[features]
+rand = ["dep:rand"]
+
 [dependencies]
-rand = "0.8.5"
+rand = { version = "0.8.5", optional = true }
 ratatui = { version = "0.29.0", default-features = false }
 
 [dev-dependencies]

--- a/src/widgets/throbber.rs
+++ b/src/widgets/throbber.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "rand")]
 use rand::Rng as _;
 
 /// State to be used for Throbber render.
@@ -32,7 +33,7 @@ impl ThrobberState {
     ///
     /// Negative numbers can also be specified for step.
     ///
-    /// If step is 0, the index is determined at random.
+    /// If feature `rand` is enabled and step is 0, the index is determined at random.
     ///
     /// # Examples:
     /// ```
@@ -46,11 +47,19 @@ impl ThrobberState {
     /// assert!((std::i8::MIN..=std::i8::MAX).contains(&throbber_state.index()))
     /// ```
     pub fn calc_step(&mut self, step: i8) {
-        self.index = if step == 0 {
-            let mut rng = rand::thread_rng();
-            rng.gen()
-        } else {
-            self.index.checked_add(step).unwrap_or(0)
+        #[cfg(feature = "rand")]
+        {
+            self.index = if step == 0 {
+                let mut rng = rand::thread_rng();
+                rng.gen()
+            } else {
+                self.index.checked_add(step).unwrap_or(0)
+            }
+        }
+
+        #[cfg(not(feature = "rand"))]
+        {
+            self.index = self.index.checked_add(step).unwrap_or(0)
         }
     }
 


### PR DESCRIPTION
Removes rand by default, but can be enabled by adding feature `rand`